### PR TITLE
Update website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!DOCTYPE HTML>
 <html>
 <head>
 <style type="text/css">
@@ -13,12 +13,14 @@ p {
 }
 </style>
 <title>jSSLKeyLog - Java Agent Library to log SSL session keys to a file for Wireshark</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.min.css" />
 </head>
 <body>
-<h1>jSSLKeyLog - Java Agent Library to log SSL session keys to a file for Wireshark</h1>
+<a class="github-fork-ribbon" href="https://github.com/jsslkeylog/jsslkeylog" title="Fork me on GitHub">Fork me on GitHub</a>
+<h1 style="margin-right: 5em">jSSLKeyLog - Java Agent Library to log SSL session keys to a file for Wireshark</h1>
 
-<p><i>&copy; 2012, 2014, 2017 Michael Schierl, <tt>&lt;schierlm at
-users dot sourceforge dot net&gt;</tt></i></p>
+<p style="margin-right: 5em"><i>&copy; 2012, 2014, 2017, 2018 Michael Schierl, <tt>&lt;schierlm at
+gmx dot de&gt;</tt></i></p>
 
 <h2>Download</h2>
 
@@ -77,27 +79,23 @@ if you are a developer) from git.</p>
 <p>Anonymous access: Use <br />
 <tt>git clone https://github.com/jsslkeylog/jsslkeylog.git jsslkeylog</tt><br />
 
-to check out the latest version. You can also use GUI programs like
-<a href="https://tortoisegit.org/">TortoiseGit (Explorer plugin)</a>.</p>
+to check out the latest version. You can also check out using Subversion, if you prefer:<br />
 
-<p>Developer access: Contact me so that I can add you to this
-project. You will need a GitHub account for this. Then you
-can use <br />
-<tt>git clone https://github.com/jsslkeylog/jsslkeylog.git jsslkeylog</tt><br />
-or
-<tt>git clone git@github.com:jsslkeylog/jsslkeylog.git jsslkeylog</tt><br />
-with your credentials. Or submit
-your changes by e-mail; then I will commit them (In the latter case
-please make sure that your <tt>From</tt> address is replyable, in case
-of any questions. <b>If my answer bounces, I will not commit your
-patch!</b>).</p>
+<tt>svn co https://github.com/jsslkeylog/jsslkeylog.git jsslkeylog</tt></p>
+
+<p>Developer access: The preferred workflow is to create a fork on GitHub
+and send a pull request via the GitHub website. If you do not have a GitHub account,
+you can also create the fork on one of the many other git hosting sites and send
+the pull request via e-mail.</p>
 
 <p>You can also <a href="https://github.com/jsslkeylog/jsslkeylog">browse the repository</a>.</p>
 
-<h2>Contact me</h2>
+<h2>Contact us</h2>
 
-<p>You can send suggestions and bug reports to my
-<a href="mailto:schierlm%40users.sourceforge.net">sourceforge e-mail address</a>.</p>
+<p>Feel free to <a href="https://github.com/jsslkeylog/jsslkeylog/issues">open an issue on GitHub</a></p>
+
+<p>If you do not have a GitHub account, you can send suggestions and bug reports to my
+<a href="mailto:schierlm%40gmx.de">e-mail address</a>.</p>
 
 <h2>Have fun!</h2>
 </body>


### PR DESCRIPTION
- Update DOCTYPE
- Add GitHub fork ribbon
- Remove references to my SourceForge email address, instead point to my
  private e-mail address and to GitHub issues
- Update "developer access" to point to the preferred git workflow (no
  patches via e-mail please :D)